### PR TITLE
Fix inventory shift

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,10 +35,10 @@ minecraft {
 }
 
 repositories {
-    maven {url "http://tehnut.info/maven"} // hwyla
-    maven {url "http://dvs1.progwml6.com/files/maven"} // jei
-    maven {url "http://maven.covers1624.net"} // te
-    maven {url "http://chickenbones.net/maven"} // chicken
+    maven {url "https://maven.tehnut.info"} // hwyla
+    maven {url "https://dvs1.progwml6.com/files/maven"} // jei
+    maven {url "https://maven.covers1624.net"} // te
+    maven {url "https://chickenbones.net/maven"} // chicken
     maven {url "https://dl.bintray.com/jaquadro/dev/"} // storage drawers
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ group_id=vswe.superfactory
 mod_name=SuperFactoryManager
 
 hwyla_version=1.8.26-B41_1.12.2
-jei_version=4.10.0.198
+jei_version=4.16.1.301

--- a/src/main/java/vswe/superfactory/SuperFactoryManager.java
+++ b/src/main/java/vswe/superfactory/SuperFactoryManager.java
@@ -23,7 +23,7 @@ import static vswe.superfactory.registry.ModBlocks.MANAGER;
 public class SuperFactoryManager {
 	public static final String              CHANNEL                      = "factorymanager";
 	public static final String              MODID                        = "superfactorymanager";
-	public static final byte                NBT_CURRENT_PROTOCOL_VERSION = 13;
+	public static final byte                NBT_CURRENT_PROTOCOL_VERSION = 14;
 	public static final String              NBT_PROTOCOL_VERSION         = "ProtocolVersion";
 	public static final String              RESOURCE_LOCATION            = "superfactorymanager";
 	public static final String              UNLOCALIZED_START            = "sfm.";

--- a/src/main/java/vswe/superfactory/tiles/TileEntityManager.java
+++ b/src/main/java/vswe/superfactory/tiles/TileEntityManager.java
@@ -6,6 +6,7 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.nbt.NBTUtil;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ITickable;
 import net.minecraft.util.math.BlockPos;
@@ -45,10 +46,12 @@ public class TileEntityManager extends TileEntity implements ITileEntityInterfac
 	private static final String NBT_COMPONENTS = "Components";
 	private static final String NBT_TIMER      = "Timer";
 	private static final String NBT_VARIABLES  = "Variables";
+	private static final String NBT_INVENTORY_POSITIONS = "InventoryPositions";
 	public              List<Button>        buttons;
 	public              boolean             justSentServerComponentRemovalPacket;
 	@SideOnly(Side.CLIENT)
 	public              IInterfaceRenderer  specialRenderer;
+	private List<BlockPos> initialInventoryPositions = new ArrayList<>(); // Used only after reading from NBT
 	List<ConnectionBlock> inventories = new ArrayList<ConnectionBlock>();
 	private             Connection          currentlyConnecting;
 	private boolean firstCommandExecution = true;
@@ -403,7 +406,35 @@ public class TileEntityManager extends TileEntity implements ITileEntityInterfac
 			}
 		}
 
-		if (!firstInventoryUpdate) {
+		if (firstInventoryUpdate) {
+			if(initialInventoryPositions.size() > 0) {
+				oldCoordinates = new WorldCoordinate[initialInventoryPositions.size()];
+				for (int i = 0; i < oldCoordinates.length; i++) {
+					final BlockPos inventoryPos = initialInventoryPositions.get(i);
+					oldCoordinates[i] = new WorldCoordinate(inventoryPos.getX(), inventoryPos.getY(), inventoryPos.getZ());
+					TileEntity inventory = world.getTileEntity(inventoryPos);
+					if (inventory == null) {
+						// Set a dummy tile entity for the case where the old tile no longer exists after a restart
+						inventory = new TileEntity() {
+						};
+						inventory.setPos(inventoryPos);
+					}
+					oldCoordinates[i].setTileEntity(inventory);
+				}
+			} else {
+				// Make the oldCoordinates match with the new ones (basically the old behaviour for the first update)
+				// Happens when first updating and inventoryPositions doesn't exist in NBT
+				// or if it had no connected inventories upon saving (nothing would have been selected anyway)
+				oldCoordinates = new WorldCoordinate[inventories.size()];
+				for (int i = 0; i < oldCoordinates.length; i++) {
+					TileEntity inventory = inventories.get(i).getTileEntity();
+					oldCoordinates[i] = new WorldCoordinate(inventory.getPos().getX(), inventory.getPos().getY(), inventory.getPos().getZ());
+					oldCoordinates[i].setTileEntity(inventory);
+				}
+			}
+		}
+
+		if (!firstInventoryUpdate || initialInventoryPositions.size() > 0) {
 			for (WorldCoordinate oldCoordinate : oldCoordinates) {
 				if (oldCoordinate.getTileEntity() instanceof ISystemListener) {
 					boolean found = false;
@@ -703,6 +734,13 @@ public class TileEntityManager extends TileEntity implements ITileEntityInterfac
 			variablesTag.appendTag(variableTag);
 		}
 		nbtTagCompound.setTag(NBT_VARIABLES, variablesTag);
+
+		NBTTagList inventoryPositionsTag = new NBTTagList();
+		for (ConnectionBlock connectionBlock : inventories) {
+			BlockPos pos = connectionBlock.getTileEntity().getPos();
+			inventoryPositionsTag.appendTag(NBTUtil.createPosTag(pos));
+		}
+		nbtTagCompound.setTag(NBT_INVENTORY_POSITIONS, inventoryPositionsTag);
 	}
 
 	public void readContentFromNBT(NBTTagCompound nbtTagCompound, boolean pickup) {
@@ -744,6 +782,15 @@ public class TileEntityManager extends TileEntity implements ITileEntityInterfac
 		for (int i = 0; i < variablesTag.tagCount(); i++) {
 			NBTTagCompound variableTag = variablesTag.getCompoundTagAt(i);
 			variables[i].readFromNBT(variableTag);
+		}
+
+		if (version >= 14) {
+			initialInventoryPositions.clear();
+			NBTTagList inventoryPositionsTag = nbtTagCompound.getTagList(NBT_INVENTORY_POSITIONS, 10);
+			for (int i = 0; i < inventoryPositionsTag.tagCount(); i++) {
+				BlockPos pos = NBTUtil.getPosFromTag(inventoryPositionsTag.getCompoundTagAt(i));
+				initialInventoryPositions.add(pos);
+			}
 		}
 	}
 

--- a/src/main/java/vswe/superfactory/tiles/TileEntityManager.java
+++ b/src/main/java/vswe/superfactory/tiles/TileEntityManager.java
@@ -434,32 +434,29 @@ public class TileEntityManager extends TileEntity implements ITileEntityInterfac
 			}
 		}
 
-		if (!firstInventoryUpdate || initialInventoryPositions.size() > 0) {
-			for (WorldCoordinate oldCoordinate : oldCoordinates) {
-				if (oldCoordinate.getTileEntity() instanceof ISystemListener) {
-					boolean found = false;
-					for (ConnectionBlock inventory : inventories) {
-						if (oldCoordinate.getX() == inventory.getTileEntity().getPos().getX() && oldCoordinate.getY() == inventory.getTileEntity().getPos().getY() && oldCoordinate.getZ() == inventory.getTileEntity().getPos().getZ()) {
-							found = true;
-							break;
-						}
-					}
-
-					if (!found) {
-						((ISystemListener) oldCoordinate.getTileEntity()).removed(this);
+		for (WorldCoordinate oldCoordinate : oldCoordinates) {
+			if (oldCoordinate.getTileEntity() instanceof ISystemListener) {
+				boolean found = false;
+				for (ConnectionBlock inventory : inventories) {
+					if (oldCoordinate.getX() == inventory.getTileEntity().getPos().getX() && oldCoordinate.getY() == inventory.getTileEntity().getPos().getY() && oldCoordinate.getZ() == inventory.getTileEntity().getPos().getZ()) {
+						found = true;
+						break;
 					}
 				}
-			}
 
-			if (!world.isRemote) {
-				updateInventorySelection(oldCoordinates);
-			} else {
-				for (FlowComponent item : items) {
-					item.setInventoryListDirty(true);
+				if (!found) {
+					((ISystemListener) oldCoordinate.getTileEntity()).removed(this);
 				}
 			}
 		}
 
+		if (!world.isRemote) {
+			updateInventorySelection(oldCoordinates);
+		} else {
+			for (FlowComponent item : items) {
+				item.setInventoryListDirty(true);
+			}
+		}
 
 		firstInventoryUpdate = false;
 	}


### PR DESCRIPTION
This PR attempts to fix https://github.com/TeamDman/SuperFactoryManager/issues/55

Prior to this PR, if the cable or connected inventories were modified and not updated before saving, it could result in the ID mappings being shifted around. This is because the IDs are based on the order of the DFS from the manager through cables.

When `updateInventories()` is called, it would do this DFS and re-map the old IDs to the new ones. The issue results from the initialization of the inventories which it does said DFS to initialize and assumes the IDs will match up, this may not be the case.

So the fix this PR does is saving the positions of the inventories associated with the current IDs to NBT so that when the manager is initialized and does the DFS for the first time, it has the old positions to update the ID mappings with.