### PR TITLE
Fix runtime inventory shift

### DIFF
--- a/src/main/java/vswe/superfactory/tiles/TileEntityManager.java
+++ b/src/main/java/vswe/superfactory/tiles/TileEntityManager.java
@@ -37,9 +37,9 @@ public class TileEntityManager extends TileEntity implements ITileEntityInterfac
 	public static final int                 BUTTON_SIZE_W       = 14;
 	public static final int                 BUTTON_SRC_X        = 242;
 	public static final int                 BUTTON_SRC_Y        = 0;
-	public static final int MAX_CABLE_LENGTH          = 128;
+	public static final int MAX_CABLE_LENGTH          = 256;
 	public static final int MAX_COMPONENT_AMOUNT      = 511;
-	public static final int MAX_CONNECTED_INVENTORIES = 1023;
+	public static final int MAX_CONNECTED_INVENTORIES = 2048;
 	public static final TriggerHelperBUD      budTrigger        = new TriggerHelperBUD();
 	public static final TriggerHelperRedstone redstoneCondition = new TriggerHelperRedstone(1, 2);
 	public static final TriggerHelperRedstone redstoneTrigger   = new TriggerHelperRedstone(3, 4);

--- a/src/main/java/vswe/superfactory/tiles/TileEntityManager.java
+++ b/src/main/java/vswe/superfactory/tiles/TileEntityManager.java
@@ -463,7 +463,8 @@ public class TileEntityManager extends TileEntity implements ITileEntityInterfac
 
 	private void addInventory(TileEntity te, WorldCoordinate target) {
 		ConnectionBlock connection        = new ConnectionBlock(te, target.getDepth());
-		boolean         isValidConnection = false;
+		// HACKY FIX: Always treat as a valid connection (better to sync from server -> client)
+		boolean isValidConnection = true;
 
 		for (ConnectionBlockType connectionBlockType : ConnectionBlockType.values()) {
 			if (connectionBlockType.isInstance(connection.getTileEntity())) {


### PR DESCRIPTION
This PR fixes one of the semi-related issues brought up by @desagas in https://github.com/TeamDman/SuperFactoryManager/issues/55, addressing this minimally by including all tiles when assigning ID mappings.

The issue occurs because some mods expose different capabilities on the server vs the client side.
This can result in a desync of inventory mappings.

The more ideal way to address this would be to synchronize the inventories between the server and the client but this should be good enough till then. @desagas has been testing out this fix for a while and no issues have cropped up.

To work with the potentially increased number of tiles being tracked, the cable length / depth and inventory limit is also doubled. Probably would be good if there was some indicator for players if the limit is reached, but that's out of scope for this PR.