### PR TITLE
1.21.1 cable facades + better overlays

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,6 +203,8 @@ dependencies {
 
     implementation "curse.maven:mekanism-268560:5656332" // Mekanism-1.21.1-10.7.4.60.jar
     implementation "mekanism:Mekanism:1.21.1-10.7.4.60:api"
+
+    implementation "curse.maven:spark-361579:5759671" // spark-1.10.109-neoforge.jar
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.

--- a/src/main/java/ca/teamdman/sfm/client/ClientStuff.java
+++ b/src/main/java/ca/teamdman/sfm/client/ClientStuff.java
@@ -2,20 +2,24 @@ package ca.teamdman.sfm.client;
 
 import ca.teamdman.sfm.SFM;
 import ca.teamdman.sfm.client.gui.screen.*;
+import ca.teamdman.sfm.client.model.CableBlockModelWrapper;
 import ca.teamdman.sfm.client.registry.SFMKeyMappings;
+import ca.teamdman.sfm.client.render.CableFacadeBlockColor;
 import ca.teamdman.sfm.client.render.FormItemExtensions;
 import ca.teamdman.sfm.client.render.PrintingPressBlockEntityRenderer;
+import ca.teamdman.sfm.common.block.CableBlock;
 import ca.teamdman.sfm.common.containermenu.ManagerContainerMenu;
 import ca.teamdman.sfm.common.net.ServerboundManagerLogDesireUpdatePacket;
 import ca.teamdman.sfm.common.registry.SFMBlockEntities;
+import ca.teamdman.sfm.common.registry.SFMBlocks;
 import ca.teamdman.sfm.common.registry.SFMItems;
-import ca.teamdman.sfm.common.registry.SFMPackets;
+import ca.teamdman.sfm.common.util.FacadeType;
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.block.BlockModelShaper;
 import net.minecraft.client.resources.language.I18n;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.contents.TranslatableContents;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
@@ -25,9 +29,10 @@ import net.minecraft.world.phys.HitResult;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.neoforge.client.event.EntityRenderersEvent;
+import net.neoforged.neoforge.client.event.ModelEvent;
+import net.neoforged.neoforge.client.event.RegisterColorHandlersEvent;
 import net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent;
 import net.neoforged.neoforge.network.PacketDistributor;
 import org.apache.commons.lang3.NotImplementedException;
@@ -149,5 +154,28 @@ public class ClientStuff {
 //            Minecraft.getInstance().keyboardHandler.setClipboard(content);
 //            SFM.LOGGER.info("Copied {} characters to clipboard", content.length());
 //        }
+    }
+
+    @SubscribeEvent
+    public static void onModelBakeEvent(ModelEvent.ModifyBakingResult event) {
+        event.getModels().computeIfPresent(
+                BlockModelShaper.stateToModelLocation(SFMBlocks.CABLE_BLOCK.get().defaultBlockState()),
+                (location, model) -> new CableBlockModelWrapper(model)
+        );
+        event.getModels().computeIfPresent(
+                BlockModelShaper.stateToModelLocation(SFMBlocks.CABLE_BLOCK.get().defaultBlockState()
+                        .setValue(CableBlock.FACADE_TYPE_PROP, FacadeType.OPAQUE_FACADE)),
+                (location, model) -> new CableBlockModelWrapper(model)
+        );
+        event.getModels().computeIfPresent(
+                BlockModelShaper.stateToModelLocation(SFMBlocks.CABLE_BLOCK.get().defaultBlockState()
+                        .setValue(CableBlock.FACADE_TYPE_PROP, FacadeType.TRANSLUCENT_FACADE)),
+                (location, model) -> new CableBlockModelWrapper(model)
+        );
+    }
+
+    @SubscribeEvent
+    public static void registerBlockColor(RegisterColorHandlersEvent.Block event) {
+        event.register(new CableFacadeBlockColor(), SFMBlocks.CABLE_BLOCK.get());
     }
 }

--- a/src/main/java/ca/teamdman/sfm/client/model/CableBlockModelWrapper.java
+++ b/src/main/java/ca/teamdman/sfm/client/model/CableBlockModelWrapper.java
@@ -1,0 +1,47 @@
+package ca.teamdman.sfm.client.model;
+
+import ca.teamdman.sfm.common.block.CableBlock;
+import ca.teamdman.sfm.common.util.FacadeType;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.Direction;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.client.ChunkRenderTypeSet;
+import net.neoforged.neoforge.client.model.BakedModelWrapper;
+import net.neoforged.neoforge.client.model.data.ModelData;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class CableBlockModelWrapper extends BakedModelWrapper<BakedModel> {
+
+    public CableBlockModelWrapper(BakedModel originalModel) {
+        super(originalModel);
+    }
+
+    @Override
+    public @NotNull List<BakedQuad> getQuads(BlockState state, Direction side, @NotNull RandomSource rand, @NotNull ModelData extraData, RenderType renderType) {
+        BlockState mimicState = extraData.get(CableBlock.FACADE_BLOCK_STATE);
+        if (mimicState == null || state.getValue(CableBlock.FACADE_TYPE_PROP) == FacadeType.NONE)
+            return originalModel.getQuads(state, side, rand, ModelData.EMPTY, renderType);
+
+        BakedModel mimicModel = Minecraft.getInstance().getBlockRenderer().getBlockModel(mimicState);
+        ChunkRenderTypeSet renderTypes = mimicModel.getRenderTypes(mimicState, rand, extraData);
+
+        if (renderType == null || renderTypes.contains(renderType)) {
+            return mimicModel.getQuads(mimicState, side, rand, ModelData.EMPTY, renderType);
+        }
+
+        return List.of();
+    }
+
+    @Override
+    public @NotNull ChunkRenderTypeSet getRenderTypes(@NotNull BlockState state, @NotNull RandomSource rand, @NotNull ModelData data) {
+        return state.getValue(CableBlock.FACADE_TYPE_PROP) == FacadeType.TRANSLUCENT_FACADE ?
+                ChunkRenderTypeSet.all() :
+                ChunkRenderTypeSet.of(RenderType.solid());
+    }
+}

--- a/src/main/java/ca/teamdman/sfm/client/render/CableFacadeBlockColor.java
+++ b/src/main/java/ca/teamdman/sfm/client/render/CableFacadeBlockColor.java
@@ -1,0 +1,25 @@
+package ca.teamdman.sfm.client.render;
+
+import ca.teamdman.sfm.common.blockentity.CableBlockEntity;
+import ca.teamdman.sfm.common.registry.SFMBlocks;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.color.block.BlockColor;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+
+public class CableFacadeBlockColor implements BlockColor {
+
+    @Override
+    public int getColor(BlockState blockState, @Nullable BlockAndTintGetter blockAndTintGetter, @Nullable BlockPos blockPos, int tintIndex) {
+        if (blockAndTintGetter == null || blockPos == null) return -1;
+
+        CableBlockEntity cableBlockEntity = (CableBlockEntity) blockAndTintGetter.getBlockEntity(blockPos);
+        if (cableBlockEntity == null) return -1;
+        BlockState facadeState = cableBlockEntity.getFacadeState();
+        if (facadeState == null || facadeState.getBlock() == SFMBlocks.CABLE_BLOCK.get()) return -1;
+
+        return Minecraft.getInstance().getBlockColors().getColor(facadeState, blockAndTintGetter, blockPos, tintIndex);
+    }
+}

--- a/src/main/java/ca/teamdman/sfm/client/render/CableFacadeBlockColor.java
+++ b/src/main/java/ca/teamdman/sfm/client/render/CableFacadeBlockColor.java
@@ -18,7 +18,7 @@ public class CableFacadeBlockColor implements BlockColor {
         CableBlockEntity cableBlockEntity = (CableBlockEntity) blockAndTintGetter.getBlockEntity(blockPos);
         if (cableBlockEntity == null) return -1;
         BlockState facadeState = cableBlockEntity.getFacadeState();
-        if (facadeState == null || facadeState.getBlock() == SFMBlocks.CABLE_BLOCK.get()) return -1;
+        if (facadeState.getBlock() == SFMBlocks.CABLE_BLOCK.get()) return -1;
 
         return Minecraft.getInstance().getBlockColors().getColor(facadeState, blockAndTintGetter, blockPos, tintIndex);
     }

--- a/src/main/java/ca/teamdman/sfm/common/block/CableBlock.java
+++ b/src/main/java/ca/teamdman/sfm/common/block/CableBlock.java
@@ -1,21 +1,50 @@
 package ca.teamdman.sfm.common.block;
 
+import ca.teamdman.sfm.common.blockentity.CableBlockEntity;
 import ca.teamdman.sfm.common.cablenetwork.CableNetworkManager;
 import ca.teamdman.sfm.common.cablenetwork.ICableBlock;
+import ca.teamdman.sfm.common.registry.SFMBlockEntities;
+import ca.teamdman.sfm.common.registry.SFMItems;
+import ca.teamdman.sfm.common.util.FacadeType;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.ItemInteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import net.neoforged.neoforge.client.model.data.ModelProperty;
+import org.jetbrains.annotations.Nullable;
 
-public class CableBlock extends Block implements ICableBlock {
+
+public class CableBlock extends Block implements ICableBlock, EntityBlock {
+    public static final ModelProperty<BlockState> FACADE_BLOCK_STATE = new ModelProperty<>();
+    public static final EnumProperty<FacadeType> FACADE_TYPE_PROP = FacadeType.FACADE_TYPE;
 
     public CableBlock() {
-        super(Block.Properties.of()
-                      .instrument(NoteBlockInstrument.BASS)
-                      .destroyTime(1f)
-                      .sound(SoundType.METAL));
+        super(Properties.of()
+                .instrument(NoteBlockInstrument.BASS)
+                .destroyTime(1f)
+                .sound(SoundType.METAL)
+        );
+
+        registerDefaultState(stateDefinition.any()
+                .setValue(FACADE_TYPE_PROP, FacadeType.NONE)
+        );
     }
 
     @SuppressWarnings("deprecation")
@@ -24,9 +53,122 @@ public class CableBlock extends Block implements ICableBlock {
         CableNetworkManager.onCablePlaced(world, pos);
     }
 
+/*
+    @Override
+    public void setPlacedBy(Level pLevel, BlockPos pPos, BlockState pState, @Nullable LivingEntity pPlacer, ItemStack pStack) {
+        if (pLevel.isClientSide() || pPlacer == null) return;
+        if (pPlacer instanceof Player pPlayer) {
+            ItemStack offHandItemStack = pPlacer.getItemInHand(InteractionHand.OFF_HAND);
+
+            setFacade(offHandItemStack, pLevel, pState, pPos, pPlayer, InteractionHand.OFF_HAND, null);
+        }
+    }
+*/
+
     @SuppressWarnings("deprecation")
     @Override
-    public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean isMoving) {
-        CableNetworkManager.onCableRemoved(level, pos);
+    public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
+        super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);
+
+        CableNetworkManager.onCableRemoved(pLevel, pPos);
+    }
+
+    @Override
+    protected ItemInteractionResult useItemOn(ItemStack pStack, BlockState pState, Level pLevel, BlockPos pPos, Player pPlayer, InteractionHand pHand, BlockHitResult pHitResult) {
+        Item offHandItem = pPlayer.getItemInHand(InteractionHand.OFF_HAND).getItem();
+        if (offHandItem == SFMItems.NETWORK_TOOL_ITEM.get()) {
+            return setFacade(pStack, pLevel, pState, pPos, pPlayer, pHand, pHitResult);
+        }
+        return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
+    }
+
+    private ItemInteractionResult setFacade(
+            ItemStack pStack,
+            Level pLevel,
+            BlockState pState,
+            BlockPos pPos,
+            Player pPlayer,
+            InteractionHand pHand,
+            @Nullable BlockHitResult pHitResult
+    ) {
+        Block block = itemStackToBlock(pStack, pLevel, pPos);
+        if (block == null) return ItemInteractionResult.FAIL;
+
+        CableBlockEntity blockEntity = getCableBlockEntity(pLevel, pPos);
+        if (blockEntity == null) return ItemInteractionResult.FAIL;
+        if (block == this) {
+            pLevel.removeBlockEntity(pPos);
+            pLevel.setBlockAndUpdate(pPos, pState.setValue(FACADE_TYPE_PROP, FacadeType.NONE));
+        } else {
+            if (pHitResult != null) {
+                // Support for block rotation
+                BlockPlaceContext blockPlaceContext = new BlockPlaceContext(pPlayer, pHand, pStack, pHitResult);
+                BlockState placedState = block.getStateForPlacement(blockPlaceContext);
+
+                if (placedState == null) return ItemInteractionResult.FAIL;
+                blockEntity.setFacadeState(placedState);
+            } else { // Should never be reached because setPlacedBy is commented out
+                blockEntity.setFacadeState(block.defaultBlockState());
+            }
+
+            // If facade block is not solid then set TRANSLUCENT block state
+            boolean isFacadeTranslucent = !blockEntity.getFacadeState().isSolidRender(pLevel, pPos);
+            pLevel.setBlockAndUpdate(pPos, pState.setValue(FACADE_TYPE_PROP, isFacadeTranslucent ? FacadeType.TRANSLUCENT_FACADE : FacadeType.OPAQUE_FACADE));
+        }
+        return ItemInteractionResult.sidedSuccess(pLevel.isClientSide());
+    }
+
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> pBuilder) {
+        pBuilder.add(FACADE_TYPE_PROP);
+    }
+
+    private @Nullable Block itemStackToBlock(ItemStack itemStack, Level pLevel, BlockPos pPos) {
+        // Empty hand should just return an SFM Cable, lets us delete the block entity
+        Item item = itemStack.getItem();
+        if (item == Items.AIR)
+            return this;
+        // Full block should return block resource, update facade
+        Block block = Block.byItem(item);
+        BlockState blockState = block.defaultBlockState();
+
+        if (blockState.isCollisionShapeFullBlock(pLevel, pPos)) {
+            return block;
+        }
+        // Non-full block or item should return null, do nothing
+        return null;
+    }
+
+    private @Nullable CableBlockEntity getCableBlockEntity(Level pLevel, BlockPos pPos) {
+        BlockEntity blockEntity = pLevel.getBlockEntity(pPos);
+        // Return existing block entity
+        if (blockEntity != null) return (CableBlockEntity) blockEntity;
+
+        // Create new block entity
+        CableBlockEntity cableBlockEntity = SFMBlockEntities.CABLE_BLOCK_ENTITY.get().create(pPos, defaultBlockState());
+        if (cableBlockEntity == null) return null;
+        pLevel.setBlockEntity(cableBlockEntity);
+        return cableBlockEntity;
+    }
+
+    @Override
+    public @Nullable BlockEntity newBlockEntity(BlockPos blockPos, BlockState blockState) {
+        // Create block entity if FACADE_TYPE is not NONE
+        return blockState.getValue(FACADE_TYPE_PROP) != FacadeType.NONE ?
+                SFMBlockEntities.CABLE_BLOCK_ENTITY.get().create(blockPos, blockState) :
+                null;
+    }
+
+    @Override
+    protected VoxelShape getOcclusionShape(BlockState pState, BlockGetter pLevel, BlockPos pPos) {
+        // Translucent blocks should have no occlusion
+        return pState.getValue(FACADE_TYPE_PROP) == FacadeType.TRANSLUCENT_FACADE ?
+                Shapes.empty() :
+                Shapes.block();
+    }
+
+    @Override
+    protected boolean propagatesSkylightDown(BlockState pState, BlockGetter pLevel, BlockPos pPos) {
+        return pState.getValue(FACADE_TYPE_PROP) == FacadeType.TRANSLUCENT_FACADE;
     }
 }

--- a/src/main/java/ca/teamdman/sfm/common/blockentity/CableBlockEntity.java
+++ b/src/main/java/ca/teamdman/sfm/common/blockentity/CableBlockEntity.java
@@ -19,23 +19,24 @@ import net.neoforged.neoforge.client.model.data.ModelData;
 import org.jetbrains.annotations.Nullable;
 
 public class CableBlockEntity extends BlockEntity {
-    private @Nullable BlockState facadeState;
+    private BlockState facadeState = SFMBlocks.CABLE_BLOCK.get().defaultBlockState();
 
     public CableBlockEntity(BlockPos pos, BlockState state) {
         super(SFMBlockEntities.CABLE_BLOCK_ENTITY.get(), pos, state);
     }
 
-    public @Nullable BlockState getFacadeState() {
+    public BlockState getFacadeState() {
         return facadeState;
     }
 
-    public void setFacadeState(BlockState newState) {
-        BlockState oldState = getBlockState();
+    public void setFacadeState(BlockState newFacadeState) {
+        if (newFacadeState == facadeState) return;
 
-        this.facadeState = newState;
+        this.facadeState = newFacadeState;
         setChanged();
         if (level != null) {
-            level.sendBlockUpdated(worldPosition, oldState, getBlockState(), Block.UPDATE_ALL);
+            BlockState state = getBlockState();
+            level.sendBlockUpdated(worldPosition, state, state, Block.UPDATE_IMMEDIATE);
         }
         requestModelDataUpdate();
     }
@@ -59,7 +60,7 @@ public class CableBlockEntity extends BlockEntity {
     @Override
     protected void saveAdditional(CompoundTag pTag, HolderLookup.Provider pRegistries) {
         super.saveAdditional(pTag, pRegistries);
-        if (facadeState != null)
+        if (facadeState.getBlock() != SFMBlocks.CABLE_BLOCK.get())
             pTag.put("facade", NbtUtils.writeBlockState(facadeState));
     }
 
@@ -68,7 +69,6 @@ public class CableBlockEntity extends BlockEntity {
         super.onDataPacket(net, pkt, lookupProvider);
 
         loadAdditional(pkt.getTag(), lookupProvider);
-        requestModelDataUpdate();
     }
 
     @Override

--- a/src/main/java/ca/teamdman/sfm/common/blockentity/CableBlockEntity.java
+++ b/src/main/java/ca/teamdman/sfm/common/blockentity/CableBlockEntity.java
@@ -1,0 +1,85 @@
+package ca.teamdman.sfm.common.blockentity;
+
+import ca.teamdman.sfm.common.block.CableBlock;
+import ca.teamdman.sfm.common.registry.SFMBlockEntities;
+import ca.teamdman.sfm.common.registry.SFMBlocks;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtUtils;
+import net.minecraft.network.Connection;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
+import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.client.model.data.ModelData;
+import org.jetbrains.annotations.Nullable;
+
+public class CableBlockEntity extends BlockEntity {
+    private @Nullable BlockState facadeState;
+
+    public CableBlockEntity(BlockPos pos, BlockState state) {
+        super(SFMBlockEntities.CABLE_BLOCK_ENTITY.get(), pos, state);
+    }
+
+    public @Nullable BlockState getFacadeState() {
+        return facadeState;
+    }
+
+    public void setFacadeState(BlockState newState) {
+        BlockState oldState = getBlockState();
+
+        this.facadeState = newState;
+        setChanged();
+        if (level != null) {
+            level.sendBlockUpdated(worldPosition, oldState, getBlockState(), Block.UPDATE_ALL);
+        }
+        requestModelDataUpdate();
+    }
+
+    @Override
+    public ModelData getModelData() {
+        return ModelData.builder().with(CableBlock.FACADE_BLOCK_STATE, facadeState).build();
+    }
+
+    @Override
+    protected void loadAdditional(CompoundTag pTag, HolderLookup.Provider pRegistries) {
+        super.loadAdditional(pTag, pRegistries);
+        if (pTag.contains("facade")) {
+            BlockState newState = NbtUtils.readBlockState(BuiltInRegistries.BLOCK.asLookup(), pTag.getCompound("facade"));
+            if (newState.getBlock() != SFMBlocks.CABLE_BLOCK.get())
+                facadeState = newState;
+            requestModelDataUpdate();
+        }
+    }
+
+    @Override
+    protected void saveAdditional(CompoundTag pTag, HolderLookup.Provider pRegistries) {
+        super.saveAdditional(pTag, pRegistries);
+        if (facadeState != null)
+            pTag.put("facade", NbtUtils.writeBlockState(facadeState));
+    }
+
+    @Override
+    public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt, HolderLookup.Provider lookupProvider) {
+        super.onDataPacket(net, pkt, lookupProvider);
+
+        loadAdditional(pkt.getTag(), lookupProvider);
+        requestModelDataUpdate();
+    }
+
+    @Override
+    public @Nullable Packet<ClientGamePacketListener> getUpdatePacket() {
+        return ClientboundBlockEntityDataPacket.create(this);
+    }
+
+    @Override
+    public CompoundTag getUpdateTag(HolderLookup.Provider pRegistries) {
+        CompoundTag pTag = new CompoundTag();
+        saveAdditional(pTag, pRegistries);
+        return pTag;
+    }
+}

--- a/src/main/java/ca/teamdman/sfm/common/item/NetworkToolItem.java
+++ b/src/main/java/ca/teamdman/sfm/common/item/NetworkToolItem.java
@@ -11,6 +11,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtUtils;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.Item;
@@ -32,7 +33,7 @@ public class NetworkToolItem extends Item {
 
     @Override
     public InteractionResult onItemUseFirst(ItemStack stack, UseOnContext pContext) {
-        if (pContext.getLevel().isClientSide) return InteractionResult.SUCCESS;
+        if (pContext.getLevel().isClientSide || pContext.getHand() == InteractionHand.OFF_HAND) return InteractionResult.SUCCESS;
 
         PacketDistributor.sendToServer(new ServerboundNetworkToolUsePacket(
                 pContext.getClickedPos(),

--- a/src/main/java/ca/teamdman/sfm/common/net/ServerboundFacadePacket.java
+++ b/src/main/java/ca/teamdman/sfm/common/net/ServerboundFacadePacket.java
@@ -1,0 +1,232 @@
+package ca.teamdman.sfm.common.net;
+
+import ca.teamdman.sfm.SFM;
+import ca.teamdman.sfm.common.block.CableBlock;
+import ca.teamdman.sfm.common.blockentity.CableBlockEntity;
+import ca.teamdman.sfm.common.cablenetwork.CableNetwork;
+import ca.teamdman.sfm.common.cablenetwork.CableNetworkManager;
+import ca.teamdman.sfm.common.registry.SFMBlockEntities;
+import ca.teamdman.sfm.common.registry.SFMBlocks;
+import ca.teamdman.sfm.common.util.FacadeType;
+import ca.teamdman.sfm.common.util.SFMUtils;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public record ServerboundFacadePacket(
+        BlockHitResult pHitResult,
+        InteractionHand pHand,
+        boolean isCtrlKeyDown,
+        boolean isAltKeyDown
+) implements CustomPacketPayload {
+    public static final Type<ServerboundFacadePacket> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(
+            SFM.MOD_ID,
+            "serverbound_facade_packet"
+    ));
+    public static final StreamCodec<FriendlyByteBuf, ServerboundFacadePacket> STREAM_CODEC = StreamCodec.ofMember(
+            ServerboundFacadePacket::encode,
+            ServerboundFacadePacket::decode
+    );
+    private static final BlockState defaultCableState = SFMBlocks.CABLE_BLOCK.get().defaultBlockState();
+
+    private static void encode(ServerboundFacadePacket msg, FriendlyByteBuf buf) {
+        buf.writeBlockHitResult(msg.pHitResult);
+        buf.writeEnum(msg.pHand);
+        buf.writeBoolean(msg.isCtrlKeyDown);
+        buf.writeBoolean(msg.isAltKeyDown);
+    }
+
+    private static ServerboundFacadePacket decode(FriendlyByteBuf buf) {
+        return new ServerboundFacadePacket(
+                buf.readBlockHitResult(),
+                buf.readEnum(InteractionHand.class),
+                buf.readBoolean(),
+                buf.readBoolean()
+        );
+    }
+
+    public static void handle(
+            ServerboundFacadePacket msg,
+            IPayloadContext ctx
+    ) {
+        // CTRL         :   Connected and Matching
+        // ALT          :   Matching
+        // CTRL + ALT   :   All
+        if (!(ctx.player() instanceof ServerPlayer sender)) {
+            return;
+        }
+
+        Level level = sender.level();
+        BlockPos hitBlockPos = msg.pHitResult.getBlockPos();
+        ItemStack itemInHand = sender.getItemInHand(msg.pHand);
+
+        Block newFacadeBlock = itemStackToBlock(
+                itemInHand,
+                level,
+                hitBlockPos
+        );
+        if (newFacadeBlock == null) return;
+
+        BlockPlaceContext blockPlaceContext = new BlockPlaceContext(sender, msg.pHand, itemInHand, msg.pHitResult);
+        BlockState placedFacadeState = Objects.requireNonNullElse(newFacadeBlock.getStateForPlacement(blockPlaceContext), newFacadeBlock.defaultBlockState());
+
+        BlockState hitBlockState = level.getBlockState(hitBlockPos);
+        { // Early return for trying to set the same facade to the same block state
+            CableBlockEntity hitBlockEntity = (CableBlockEntity) level.getBlockEntity(hitBlockPos);
+            BlockState hitFacadeState = hitBlockEntity != null ? hitBlockEntity.getFacadeState() : null;
+
+            if (hitFacadeState == placedFacadeState ||
+                    (hitBlockState == defaultCableState && newFacadeBlock == SFMBlocks.CABLE_BLOCK.get())
+            ) {
+                return;
+            }
+        }
+
+        Stream<BlockPos> toSetFacade = gatherCableBlocksToFacade(msg, level, hitBlockPos);
+
+        FacadeType facadeProperty = newFacadeBlock == SFMBlocks.CABLE_BLOCK.get() ?
+                FacadeType.NONE :
+                placedFacadeState.isSolidRender(level, hitBlockPos) ?
+                        FacadeType.OPAQUE_FACADE : FacadeType.TRANSLUCENT_FACADE;
+        BlockState newBlockState = hitBlockState.setValue(CableBlock.FACADE_TYPE_PROP, facadeProperty);
+
+        toSetFacade
+                .forEach(blockPos -> {
+                    CableBlockEntity cableBlockEntity = getCableBlockEntity(level, blockPos);
+                    if (cableBlockEntity == null) return;
+
+                    if (newFacadeBlock == SFMBlocks.CABLE_BLOCK.get()) {
+                        cableBlockEntity.setFacadeState(defaultCableState);
+                        level.removeBlockEntity(blockPos);
+                    } else {
+                        cableBlockEntity.setFacadeState(placedFacadeState);
+                    }
+                    level.setBlock(blockPos, newBlockState, Block.UPDATE_IMMEDIATE);
+                });
+    }
+
+    private static Stream<BlockPos> gatherCableBlocksToFacade(
+            ServerboundFacadePacket pMsg,
+            Level pLevel,
+            BlockPos pPos
+    ) {
+        if (pMsg.isCtrlKeyDown && pMsg.isAltKeyDown) {
+            // Return all cable blocks on network
+            return CableNetworkManager.getNetworksForLevel(pLevel)
+                    .flatMap(CableNetwork::getCablePositions)
+                    .distinct();
+        } else if (pMsg.isAltKeyDown) {
+            // Match blocks with no block entity
+            // If block entity exists then check block of facade state
+
+            CableBlockEntity cableBlockEntity = (CableBlockEntity) pLevel.getBlockEntity(pPos);
+            if (cableBlockEntity == null) {
+                return CableNetworkManager.getNetworksForLevel(pLevel)
+                        .flatMap(CableNetwork::getCablePositions)
+                        .filter(cableBlockPos -> (pLevel.getBlockEntity(cableBlockPos) == null))
+                        .distinct();
+            }
+
+            Block oldFacadeBlock = cableBlockEntity.getFacadeState().getBlock();
+            return CableNetworkManager.getNetworksForLevel(pLevel)
+                    .flatMap(CableNetwork::getCablePositions)
+                    .filter(cableBlockPos -> {
+                        CableBlockEntity newCableBlockEntity = (CableBlockEntity) pLevel.getBlockEntity(cableBlockPos);
+                        if (newCableBlockEntity == null) return false;
+                        return oldFacadeBlock == newCableBlockEntity.getFacadeState().getBlock();
+                    })
+                    .distinct();
+        } else if (pMsg.isCtrlKeyDown) {
+            // Block must be connected to starting block
+            // Match blocks with no block entity
+            // If block entity exists then check block of facade state
+
+            CableBlockEntity cableBlockEntity = (CableBlockEntity) pLevel.getBlockEntity(pPos);
+            if (cableBlockEntity == null) {
+                return SFMUtils.getRecursiveStream((current, nextQueue, results) -> {
+                            results.accept(current);
+
+                            SFMUtils.get3DNeighboursIncludingKittyCorner(current)
+                                    .filter(neighborPos -> pLevel.getBlockState(neighborPos)
+                                            .getBlock() == SFMBlocks.CABLE_BLOCK.get())
+                                    .filter(neighborPos -> {
+                                        CableBlockEntity neighborCableBlockEntity = (CableBlockEntity) pLevel.getBlockEntity(neighborPos);
+                                        return neighborCableBlockEntity == null;
+                                    })
+                                    .forEach(nextQueue);
+                        }, pPos)
+                        .distinct();
+            }
+
+            Block facadeBlock = cableBlockEntity.getFacadeState().getBlock();
+            return SFMUtils.getRecursiveStream((current, nextQueue, results) -> {
+                        results.accept(current);
+
+                        SFMUtils.get3DNeighboursIncludingKittyCorner(current)
+                                .filter(neighborPos -> pLevel.getBlockState(neighborPos)
+                                        .getBlock() == SFMBlocks.CABLE_BLOCK.get())
+                                .filter(neighborPos -> {
+                                    CableBlockEntity neighborCableBlockEntity = (CableBlockEntity) pLevel.getBlockEntity(neighborPos);
+                                    if (neighborCableBlockEntity == null) return false;
+                                    return neighborCableBlockEntity.getFacadeState().getBlock() == facadeBlock;
+                                })
+                                .forEach(nextQueue);
+                    }, pPos)
+                    .distinct();
+
+        } else {
+            return Stream.of(pPos);
+        }
+    }
+
+    private static @Nullable Block itemStackToBlock(ItemStack itemStack, Level pLevel, BlockPos pPos) {
+        // Empty hand should just return an SFM Cable, lets us delete the block entity
+        Item item = itemStack.getItem();
+        if (item == Items.AIR)
+            return SFMBlocks.CABLE_BLOCK.get();
+        // Full block should return block resource, update facade
+        Block block = Block.byItem(item);
+        BlockState blockState = block.defaultBlockState();
+
+        if (blockState.isCollisionShapeFullBlock(pLevel, pPos)) {
+            return block;
+        }
+        // Non-full block or item should return null, do nothing
+        return null;
+    }
+
+    private static @Nullable CableBlockEntity getCableBlockEntity(Level pLevel, BlockPos pPos) {
+        BlockEntity blockEntity = pLevel.getBlockEntity(pPos);
+        // Return existing block entity
+        if (blockEntity != null) return (CableBlockEntity) blockEntity;
+
+        // Create new block entity
+        CableBlockEntity cableBlockEntity = SFMBlockEntities.CABLE_BLOCK_ENTITY.get().create(pPos, defaultCableState);
+        if (cableBlockEntity == null) return null;
+        pLevel.setBlockEntity(cableBlockEntity);
+        return cableBlockEntity;
+    }
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/ca/teamdman/sfm/common/registry/SFMBlockEntities.java
+++ b/src/main/java/ca/teamdman/sfm/common/registry/SFMBlockEntities.java
@@ -28,6 +28,14 @@ public final class SFMBlockEntities {
                     .of(ManagerBlockEntity::new, SFMBlocks.MANAGER_BLOCK.get())
                     .build(null)
     );
+
+    public static final Supplier<BlockEntityType<CableBlockEntity>> CABLE_BLOCK_ENTITY = BLOCK_ENTITY_TYPES.register(
+            "cable",
+            () -> BlockEntityType.Builder
+                    .of(CableBlockEntity::new, SFMBlocks.CABLE_BLOCK.get())
+                    .build(null)
+    );
+
     public static final Supplier<BlockEntityType<PrintingPressBlockEntity>> PRINTING_PRESS_BLOCK_ENTITY = BLOCK_ENTITY_TYPES.register(
             "printing_press",
             () -> BlockEntityType.Builder

--- a/src/main/java/ca/teamdman/sfm/common/registry/SFMPackets.java
+++ b/src/main/java/ca/teamdman/sfm/common/registry/SFMPackets.java
@@ -165,6 +165,11 @@ public class SFMPackets {
                 ClientboundBoolExprStatementInspectionResultsPacket.STREAM_CODEC,
                 ClientboundBoolExprStatementInspectionResultsPacket::handle
         );
+        registrar.playToServer(
+                ServerboundFacadePacket.TYPE,
+                ServerboundFacadePacket.STREAM_CODEC,
+                ServerboundFacadePacket::handle
+        );
     }
 
     public static <MENU extends AbstractContainerMenu, BE extends BlockEntity> void handleServerboundContainerPacket(

--- a/src/main/java/ca/teamdman/sfm/common/util/FacadeType.java
+++ b/src/main/java/ca/teamdman/sfm/common/util/FacadeType.java
@@ -1,0 +1,20 @@
+package ca.teamdman.sfm.common.util;
+
+import net.minecraft.util.StringRepresentable;
+import net.minecraft.world.level.block.state.properties.EnumProperty;
+
+public enum FacadeType implements StringRepresentable {
+    NONE, OPAQUE_FACADE, TRANSLUCENT_FACADE;
+    public static final EnumProperty<FacadeType> FACADE_TYPE = EnumProperty.create("facade_type", FacadeType.class);
+
+    FacadeType() {}
+
+    @Override
+    public String getSerializedName() {
+        return switch (this) {
+            case NONE -> "none";
+            case OPAQUE_FACADE -> "opaque";
+            case TRANSLUCENT_FACADE -> "translucent";
+        };
+    }
+}


### PR DESCRIPTION
Adds cable facades when holding the network tool in your offhand and right clicking with any full collision block.
Updating the model isn't completely perfect, but doesn't have any major issues.
Use an empty hand or cable block to clear facade, with network tool in offhand.


Network tool also has several modifier keys to place facades faster
| Keybind | Action |
|--------|--------|
| CTRL | Connected and Matching |
| ALT | Matching |
| CTRL + ALT | All Cables | 

Overlays check if the face direction is also an overlay, in which case it doesn't render that face. Draws less quads (more FPS) and isn't blinding.