### PR TITLE
Add blacklisting of resource types

### DIFF
--- a/src/main/java/ca/teamdman/sfm/client/gui/screen/ExamplesScreen.java
+++ b/src/main/java/ca/teamdman/sfm/client/gui/screen/ExamplesScreen.java
@@ -1,5 +1,6 @@
 package ca.teamdman.sfm.client.gui.screen;
 
+import ca.teamdman.sfm.common.SFMConfig;
 import ca.teamdman.sfm.common.localization.LocalizationKeys;
 import ca.teamdman.sfm.common.registry.SFMResourceTypes;
 import ca.teamdman.sfml.ast.Program;
@@ -16,6 +17,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -43,10 +45,17 @@ public class ExamplesScreen extends Screen {
             try (BufferedReader reader = entry.getValue().openAsReader()) {
                 String program = reader.lines().collect(Collectors.joining("\n"));
                 if (program.contains("$REPLACE_RESOURCE_TYPES_HERE$")) {
+                    List<? extends String> blacklistedResources = SFMConfig.getOrDefault(SFMConfig.COMMON.blacklistedResourceTypesForTransfer);
                     var replacement = SFMResourceTypes.DEFERRED_TYPES.keySet()
                             .stream()
                             .map(ResourceLocation::getPath)
-                            .map(e -> "INPUT " + e + ":: FROM a")
+                            .map(e -> {
+                                String text = "";
+                                if (blacklistedResources.contains(e))
+                                    text += "-- BLACKLISTED: ";
+                                text += "INPUT " + e + ":: FROM a";
+                                return text;
+                            })
                             .collect(Collectors.joining("\n    "));
                     program = program.replace("$REPLACE_RESOURCE_TYPES_HERE$", replacement);
                 }

--- a/src/main/java/ca/teamdman/sfm/common/SFMConfig.java
+++ b/src/main/java/ca/teamdman/sfm/common/SFMConfig.java
@@ -6,6 +6,8 @@ import net.neoforged.fml.config.ModConfig;
 import net.neoforged.neoforge.common.ModConfigSpec;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.util.List;
+
 public class SFMConfig {
     public static final ModConfigSpec COMMON_SPEC;
     public static final ModConfigSpec CLIENT_SPEC;
@@ -24,6 +26,7 @@ public class SFMConfig {
         public final ModConfigSpec.IntValue timerTriggerMinimumIntervalInTicks;
         public final ModConfigSpec.IntValue timerTriggerMinimumIntervalInTicksWhenOnlyForgeEnergyIO;
         public final ModConfigSpec.IntValue maxIfStatementsInTriggerBeforeSimulationIsntAllowed;
+        public final ModConfigSpec.ConfigValue<List<? extends String>> blacklistedResourceTypesForTransfer;
 
         Common(ModConfigSpec.Builder builder) {
             timerTriggerMinimumIntervalInTicks = builder
@@ -39,6 +42,9 @@ public class SFMConfig {
                     .comment(
                             "The number of scenarios to check is 2^n where n is the number of if statements in a trigger")
                     .defineInRange("maxIfStatementsInTriggerBeforeSimulationIsntAllowed", 10, 0, Integer.MAX_VALUE);
+            blacklistedResourceTypesForTransfer = builder
+                    .comment("What resource types should SFM not be allowed to move")
+                    .defineListAllowEmpty("blacklistedResourceTypes", List.of(), s -> s instanceof String);
         }
     }
 

--- a/src/main/java/ca/teamdman/sfml/ast/ASTBuilder.java
+++ b/src/main/java/ca/teamdman/sfml/ast/ASTBuilder.java
@@ -15,6 +15,7 @@ public class ASTBuilder extends SFMLBaseVisitor<ASTNode> {
     private final Set<Label> USED_LABELS = new HashSet<>();
     private final Set<ResourceIdentifier<?, ?, ?>> USED_RESOURCES = new HashSet<>();
     private final List<Pair<ASTNode, ParserRuleContext>> AST_NODE_CONTEXTS = new LinkedList<>();
+    private final List<? extends String> BLACKLISTED_RESOURCES = SFMConfig.getOrDefault(SFMConfig.COMMON.blacklistedResourceTypesForTransfer);
 
     public List<Pair<ASTNode, ParserRuleContext>> getNodesUnderCursor(int cursorPos) {
         return AST_NODE_CONTEXTS
@@ -79,6 +80,9 @@ public class ASTBuilder extends SFMLBaseVisitor<ASTNode> {
                 .replaceAll(":$", ":*")
                 .replaceAll("\\*", ".*");
         var rtn = ResourceIdentifier.fromString(str);
+        if (BLACKLISTED_RESOURCES.contains(rtn.resourceTypeName)) {
+            throw new IllegalArgumentException("Resource type \"" + rtn.resourceTypeName + "\" is blacklisted");
+        }
         USED_RESOURCES.add(rtn);
         rtn.assertValid();
         AST_NODE_CONTEXTS.add(new Pair<>(rtn, ctx));

--- a/src/main/java/ca/teamdman/sfml/ast/ASTBuilder.java
+++ b/src/main/java/ca/teamdman/sfml/ast/ASTBuilder.java
@@ -80,9 +80,6 @@ public class ASTBuilder extends SFMLBaseVisitor<ASTNode> {
                 .replaceAll(":$", ":*")
                 .replaceAll("\\*", ".*");
         var rtn = ResourceIdentifier.fromString(str);
-        if (BLACKLISTED_RESOURCES.contains(rtn.resourceTypeName)) {
-            throw new IllegalArgumentException("Resource type \"" + rtn.resourceTypeName + "\" is blacklisted");
-        }
         USED_RESOURCES.add(rtn);
         rtn.assertValid();
         AST_NODE_CONTEXTS.add(new Pair<>(rtn, ctx));
@@ -257,6 +254,14 @@ public class ASTBuilder extends SFMLBaseVisitor<ASTNode> {
     public InputStatement visitInputStatement(SFMLParser.InputStatementContext ctx) {
         var labelAccess = visitLabelAccess(ctx.labelAccess());
         var matchers = visitInputResourceLimits(ctx.inputResourceLimits());
+
+        matchers.resourceLimitList().forEach(resourceLimit -> {
+            resourceLimit.resourceIds().stream().forEach(resourceId -> {
+                if (BLACKLISTED_RESOURCES.contains(resourceId.resourceTypeName))
+                    throw new IllegalArgumentException("Resource type \"" + resourceId.resourceTypeName + "\" is blacklisted");
+            });
+        });
+
         var exclusions = visitResourceExclusion(ctx.resourceExclusion());
         var each = ctx.EACH() != null;
         InputStatement inputStatement = new InputStatement(labelAccess, matchers.withExclusions(exclusions), each);
@@ -268,6 +273,14 @@ public class ASTBuilder extends SFMLBaseVisitor<ASTNode> {
     public OutputStatement visitOutputStatement(SFMLParser.OutputStatementContext ctx) {
         var labelAccess = visitLabelAccess(ctx.labelAccess());
         var matchers = visitOutputResourceLimits(ctx.outputResourceLimits());
+
+        matchers.resourceLimitList().forEach(resourceLimit -> {
+            resourceLimit.resourceIds().stream().forEach(resourceId -> {
+                if (BLACKLISTED_RESOURCES.contains(resourceId.resourceTypeName))
+                    throw new IllegalArgumentException("Resource type \"" + resourceId.resourceTypeName + "\" is blacklisted");
+            });
+        });
+
         var exclusions = visitResourceExclusion(ctx.resourceExclusion());
         var each = ctx.EACH() != null;
         OutputStatement outputStatement = new OutputStatement(labelAccess, matchers.withExclusions(exclusions), each);


### PR DESCRIPTION
Adds a simple config option to blacklist resource types
Might eventually need to be expanded to support namespaces other than sfm, or specific resources (ie mekanism spent waste)

Closes #174 