### PR TITLE
Fix ANTLR grammar: add catch-all hidden lexer rule to prevent tokeniz…

### DIFF
--- a/platform/visual-studio-code/super-factory-manager-language/syntaxes/SFML.g4
+++ b/platform/visual-studio-code/super-factory-manager-language/syntaxes/SFML.g4
@@ -4,7 +4,7 @@ grammar SFML;
 
 //go to SFMLLexer.ts after going antlr command on the package.json and solve the 2 issues
 @lexer::members {
-    public boolean INCLUDE_UNUSED = false; // we want syntax highlighting to not break on unexpected tokens
+    public INCLUDE_UNUSED: boolean = false; // we want syntax highlighting to not break on unexpected tokens
 }
 
 program : name? trigger* EOF;
@@ -279,7 +279,7 @@ WS
         ;
 
 UNUSED
-        :   {INCLUDE_UNUSED}? . -> channel(HIDDEN)
+        :   {this.INCLUDE_UNUSED}? . -> channel(HIDDEN)
         ;
 
 fragment A  :('a' | 'A') ;


### PR DESCRIPTION
I've been using the generated antlr files on my [editor](https://sfmhub.site/code-editor) (Yes, I'm that guy)
And I noticed some mismatched syntax errors when using "back side" or "front side" even though they were in the code. Upon investigating, I noticed that there was some Java code on the platform/visual-studio-code/super-factory-manager-language/syntaxes/SFML.g4 file, and as the target is typescript, I changed it to the correct grammar syntax.
PS: I did not regenerate the antlr files for this PR, to update the extension, you still have to run the antlr command.