### PR TITLE
feat(1.19.2 mod): make fancy cables waterloggable (#533)

### DIFF
--- a/platform/minecraft/src/main/java/ca/teamdman/sfm/common/block/FancyCableBlock.java
+++ b/platform/minecraft/src/main/java/ca/teamdman/sfm/common/block/FancyCableBlock.java
@@ -14,9 +14,13 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.SimpleWaterloggedBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
@@ -25,7 +29,9 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public class FancyCableBlock extends CableBlock implements IFacadableBlock {
+public class FancyCableBlock extends CableBlock implements IFacadableBlock, SimpleWaterloggedBlock {
+    public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
+
     public static final BooleanProperty NORTH = BooleanProperty.create("north");
 
     public static final BooleanProperty SOUTH = BooleanProperty.create("south");
@@ -73,6 +79,7 @@ public class FancyCableBlock extends CableBlock implements IFacadableBlock {
         super(properties);
         registerDefaultState(
                 defaultBlockState()
+                        .setValue(WATERLOGGED, false)
                         .setValue(NORTH, false)
                         .setValue(SOUTH, false)
                         .setValue(EAST, false)
@@ -80,6 +87,13 @@ public class FancyCableBlock extends CableBlock implements IFacadableBlock {
                         .setValue(UP, false)
                         .setValue(DOWN, false)
         );
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public FluidState getFluidState(BlockState state) {
+
+        return state.getValue(WATERLOGGED) ? Fluids.WATER.getSource(false) : super.getFluidState(state);
     }
 
     @Override
@@ -97,7 +111,9 @@ public class FancyCableBlock extends CableBlock implements IFacadableBlock {
     @Override
     public @Nullable BlockState getStateForPlacement(BlockPlaceContext ctx) {
 
-        return getState(defaultBlockState(), ctx.getLevel(), ctx.getClickedPos());
+        FluidState fluid = ctx.getLevel().getFluidState(ctx.getClickedPos());
+        BlockState base = defaultBlockState().setValue(WATERLOGGED, fluid.getType() == Fluids.WATER);
+        return getState(base, ctx.getLevel(), ctx.getClickedPos());
     }
 
     @SuppressWarnings("deprecation")
@@ -139,6 +155,9 @@ public class FancyCableBlock extends CableBlock implements IFacadableBlock {
             BlockPos facingPos
     ) {
 
+        if (state.getValue(WATERLOGGED)) {
+            world.scheduleTick(pos, Fluids.WATER, Fluids.WATER.getTickDelay(world));
+        }
         return getState(state, world, pos);
     }
 
@@ -148,7 +167,9 @@ public class FancyCableBlock extends CableBlock implements IFacadableBlock {
             BlockPos pos
     ) {
 
-        return getState(defaultBlockState(), level, pos);
+        FluidState fluid = level.getFluidState(pos);
+        BlockState base = defaultBlockState().setValue(WATERLOGGED, fluid.getType() == Fluids.WATER);
+        return getState(base, level, pos);
     }
 
     protected static VoxelShape getShape(BlockState state) {
@@ -178,7 +199,7 @@ public class FancyCableBlock extends CableBlock implements IFacadableBlock {
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
 
         super.createBlockStateDefinition(builder);
-        builder.add(NORTH, SOUTH, EAST, WEST, UP, DOWN);
+        builder.add(WATERLOGGED, NORTH, SOUTH, EAST, WEST, UP, DOWN);
     }
 
     protected BlockState getState(


### PR DESCRIPTION
Implements SimpleWaterloggedBlock on FancyCableBlock — all variants inherit automatically. Fixes #533 