### PR TITLE
perf: swap isDone and matchesStack checks

### DIFF
--- a/platform/minecraft/src/main/java/ca/teamdman/sfm/common/program/LimitedInputSlot.java
+++ b/platform/minecraft/src/main/java/ca/teamdman/sfm/common/program/LimitedInputSlot.java
@@ -58,11 +58,11 @@ public class LimitedInputSlot<STACK, ITEM, CAP> implements LimitedSlot<STACK, IT
             done = true;
             return true;
         }
-        if (!tracker.matchesStack(stack)) {
+        if (tracker.isDone(type, stack)) {
             done = true;
             return true;
         }
-        if (tracker.isDone(type, stack)) {
+        if (!tracker.matchesStack(stack)) {
             done = true;
             return true;
         }

--- a/platform/minecraft/src/main/java/ca/teamdman/sfm/common/program/LimitedOutputSlot.java
+++ b/platform/minecraft/src/main/java/ca/teamdman/sfm/common/program/LimitedOutputSlot.java
@@ -51,10 +51,10 @@ public class LimitedOutputSlot<STACK, ITEM, CAP> implements LimitedSlot<STACK, I
         if (count >= type.getMaxStackSizeForSlot(handler, slot)) {
             return true;
         }
-        if (count != 0 && !tracker.matchesStack(stack)) {
+        if (tracker.isDone(type, stack)) {
             return true;
         }
-        if (tracker.isDone(type, stack)) {
+        if (count != 0 && !tracker.matchesStack(stack)) {
             return true;
         }
         return false;

--- a/platform/minecraft/src/main/java/ca/teamdman/sfm/common/program/LimitedOutputSlot.java
+++ b/platform/minecraft/src/main/java/ca/teamdman/sfm/common/program/LimitedOutputSlot.java
@@ -47,11 +47,12 @@ public class LimitedOutputSlot<STACK, ITEM, CAP> implements LimitedSlot<STACK, I
             return true;
         }
         STACK stack = getStackInSlot();
-        long count = type.getAmount(stack);
-        if (count >= type.getMaxStackSizeForSlot(handler, slot)) {
+        if (tracker.isDone(type, stack)) {
             return true;
         }
-        if (tracker.isDone(type, stack)) {
+
+        long count = type.getAmount(stack);
+        if (count >= type.getMaxStackSizeForSlot(handler, slot)) {
             return true;
         }
         if (count != 0 && !tracker.matchesStack(stack)) {


### PR DESCRIPTION
<img width="2880" height="1778" alt="image" src="https://github.com/user-attachments/assets/fa215f8f-d8bf-4d3e-8fb3-3347ebd3d0d8" />

`a` and `b` are double chests each with 45 stacks of deepslate coal ore
- pre-patch: about 0.32ms
- post-patch: about 0.2ms

not 100% confident in those statistics (please we need better stats)

also not 100% confident in behaviour staying the same but as far as im concerned, matchesStack shouldn't have any meaningful side effects