### PR TITLE
Fix HAS EXCEPT conditions

### DIFF
--- a/platform/minecraft/src/gametest/java/ca/teamdman/sfm/gametest/tests/general/HasExceptGameTest.java
+++ b/platform/minecraft/src/gametest/java/ca/teamdman/sfm/gametest/tests/general/HasExceptGameTest.java
@@ -1,0 +1,56 @@
+package ca.teamdman.sfm.gametest.tests.general;
+
+import ca.teamdman.sfm.common.registry.registration.SFMBlocks;
+import ca.teamdman.sfm.gametest.SFMGameTest;
+import ca.teamdman.sfm.gametest.SFMGameTestDefinition;
+import ca.teamdman.sfm.gametest.SFMGameTestHelper;
+import ca.teamdman.sfm.gametest.declarative.SFMDeclarativeTestBuilder;
+import ca.teamdman.sfm.gametest.declarative.SFMTestBlockEntitySpec;
+import ca.teamdman.sfm.gametest.declarative.SFMTestSpec;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.Container;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+@SFMGameTest
+public class HasExceptGameTest extends SFMGameTestDefinition {
+
+    @Override
+    public String template() {
+        return "3x2x1";
+    }
+
+    @Override
+    public void run(SFMGameTestHelper helper) {
+        SFMTestSpec spec = new SFMTestSpec()
+                .setProgram("""
+                        EVERY 20 TICKS DO
+                            IF a HAS EQ 1 EXCEPT stick THEN
+                                INPUT 1 oak_planks FROM a
+                                OUTPUT TO b
+                            END
+                        END
+                    """)
+                .addBlock(SFMTestBlockEntitySpec.<BlockEntity>of(
+                        "a",
+                        new BlockPos(1, 0, 0),
+                        SFMBlocks.TEST_BARREL.get(),
+                        blockEntity -> {
+                            Container container = (Container) blockEntity;
+                            container.setItem(0, new ItemStack(Items.STICK));
+                            container.setItem(1, new ItemStack(Items.OAK_PLANKS));
+                        }
+                ))
+                .addBlock(SFMTestBlockEntitySpec.of(
+                        "b",
+                        new BlockPos(-1, 0, 0),
+                        SFMBlocks.TEST_BARREL.get()
+                ))
+                .preCondition("a HAS EQ 1 EXCEPT stick")
+                .postCondition("a HAS EQ 0 EXCEPT stick")
+                .postCondition("a HAS EQ 1 stick")
+                .postCondition("b HAS EQ 1 oak_planks");
+        new SFMDeclarativeTestBuilder(helper, spec).run();
+    }
+}

--- a/platform/minecraft/src/main/java/ca/teamdman/sfml/ast/BoolHas.java
+++ b/platform/minecraft/src/main/java/ca/teamdman/sfml/ast/BoolHas.java
@@ -93,7 +93,8 @@ public record BoolHas(
                 labelAccess.sides(),
                 pos,
                 (direction, cap) -> resourceType.getStacksInSlots(cap, labelAccess.slots()).forEach(stack -> {
-                    if (this.resourceIdSet.getMatchingFromStack(stack) != null) {
+                    if (this.except.noneMatchStack(stack)
+                            && this.resourceIdSet.getMatchingFromStack(stack) != null) {
                         if (with.matchesStack(resourceType, stack)) {
                             long amount = resourceType.getAmount(stack);
                             invAccumulator.addAndGet(amount);

--- a/platform/minecraft/src/main/resources/assets/sfm/template_programs/changelog.sfml
+++ b/platform/minecraft/src/main/resources/assets/sfm/template_programs/changelog.sfml
@@ -18,6 +18,7 @@ NAME "Changelog"
 -- Add copy and paste support to the draw canvas
 -- Improve draw canvas selection highlight positioning while panning
 -- Add a draw canvas Done button tooltip for the Shift+Enter shortcut
+-- Fix HAS conditions ignoring resources listed with EXCEPT, fixes #319
 
 ---- 4.34.0 ----
 -- Update zh_cn localizations, thanks @ZHAY10086 #526


### PR DESCRIPTION
Fixes #319

What changed:
- Make HAS EXCEPT skip stacks matching excluded resources.
- Add a declarative GameTest covering a barrel with stick and oak planks.
- Add the 4.35.0 changelog entry.

Validation:
- sfm-propagate-changes.exe run compile --branch agent/fix-319-except-condition --wait-for-build-lock
- sfm-propagate-changes.exe game-test run-server --branch agent/fix-319-except-condition --filter has_except --wait-for-build-lock