### PR TITLE
Fix manager screen tick history crash

### DIFF
--- a/platform/minecraft/src/main/java/ca/teamdman/sfm/client/screen/ManagerScreen.java
+++ b/platform/minecraft/src/main/java/ca/teamdman/sfm/client/screen/ManagerScreen.java
@@ -742,7 +742,7 @@ public class ManagerScreen extends AbstractContainerScreen<ManagerContainerMenu>
         Duration peakTickTime = Duration.ZERO;
         for (int i = 0; i < menu.tickTimes.length; i++) {
             Duration candidate = menu.tickTimes[i];
-            if (candidate.compareTo(peakTickTime) > 0) {
+            if (candidate != null && candidate.compareTo(peakTickTime) > 0) {
                 peakTickTime = candidate;
             }
         }
@@ -780,7 +780,8 @@ public class ManagerScreen extends AbstractContainerScreen<ManagerContainerMenu>
         bufferbuilder.begin(VertexFormat.Mode.DEBUG_LINE_STRIP, DefaultVertexFormat.POSITION_COLOR);
         int mouseTickTimeIndex = -1;
         for (int i = 0; i < menu.tickTimes.length; i++) {
-            long y = menu.tickTimes[i].toNanos();
+            Duration tickTime = menu.tickTimes[i];
+            long y = tickTime == null ? 0 : tickTime.toNanos();
             float normalizedTickTime = y == 0 ? 0 : (float) (Math.log10(y) / Math.log10(yMax));
             int plotPosY = plotY + plotHeight - (int) (normalizedTickTime * plotHeight);
 
@@ -813,7 +814,8 @@ public class ManagerScreen extends AbstractContainerScreen<ManagerContainerMenu>
         if (mouseTickTimeIndex != -1) { // We are hovering over the plot
             // Draw the tick time text for the hovered point instead of peak
             {
-                long hoveredTickTimeNanoseconds = menu.tickTimes[mouseTickTimeIndex].toNanos();
+                Duration hoveredTickTime = menu.tickTimes[mouseTickTimeIndex];
+                long hoveredTickTimeNanoseconds = hoveredTickTime == null ? 0 : hoveredTickTime.toNanos();
                 var hoveredTickTimeMilliseconds = hoveredTickTimeNanoseconds / 1_000_000f;
                 String formattedMillis = format.format(hoveredTickTimeMilliseconds);
                 ChatFormatting lagColor = getMillisecondColour(hoveredTickTimeMilliseconds);

--- a/platform/minecraft/src/main/resources/assets/sfm/template_programs/changelog.sfml
+++ b/platform/minecraft/src/main/resources/assets/sfm/template_programs/changelog.sfml
@@ -18,6 +18,7 @@ NAME "Changelog"
 -- Add copy and paste support to the draw canvas
 -- Improve draw canvas selection highlight positioning while panning
 -- Add a draw canvas Done button tooltip for the Shift+Enter shortcut
+-- Fix manager screen crash when opening before tick-time history is populated, fixes #535
 
 ---- 4.34.0 ----
 -- Update zh_cn localizations, thanks @ZHAY10086 #526


### PR DESCRIPTION
Fixes #535

## Summary

Opening the manager screen before any program has produced tick-time samples can crash while rendering the performance graph. The history contains null entries until samples exist.

This change treats null samples as zero-duration values for peak calculation, graph plotting, and hover text, preserving normal graph behavior once timing data arrives. It also adds a changelog entry.

## Validation

- `sfm-propagate-changes.exe run compile --branch agent/fix-535-manager-screen-null --wait-for-build-lock`
- `sfm-propagate-changes.exe test run --branch agent/fix-535-manager-screen-null --wait-for-build-lock`
